### PR TITLE
Refactor NPC promotion creature template SQL

### DIFF
--- a/data/sql/db-world/base/npc_promotion_creature_template.sql
+++ b/data/sql/db-world/base/npc_promotion_creature_template.sql
@@ -1,38 +1,5 @@
 DELETE FROM `creature_template` WHERE `entry`=100002;
-INSERT INTO `creature_template`(
-`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`,
-`KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`,
-`gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`,
-`npcflag`, `speed_walk`, `speed_run`, `speed_swim`, `speed_flight`,
-`detection_range`, `scale`, `rank`, `dmgschool`, `DamageModifier`,
-`BaseAttackTime`, `RangeAttackTime`, `BaseVariance`, `RangeVariance`,
-`unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`,
-`family`, `type`, `type_flags`,
-`lootid`, `pickpocketloot`, `skinloot`,
-`PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`,
-`AIName`, `MovementType`, `HoverHeight`,
-`HealthModifier`, `ManaModifier`, `ArmorModifier`,
-`ExperienceModifier`, `RacialLeader`, `movementId`,
-`RegenHealth`, `mechanic_immune_mask`,
-`spell_school_immune_mask`, `flags_extra`,
-`ScriptName`, `VerifiedBuild`
-) VALUES
-(100002,0,0,0,
-0,0,'AzerothCore','Promotion',NULL,
-62000,80,80,0,35,
-1,1,1.14286,1,1,
-20,1.5,0,0,1,
-0,0,1,1,
-1,0,0,0,
-0,0,0,
-0,0,0,
-0,0,0,0,
-'',0,1,
-1,1,1,
-1,0,0,
-1,0,
-0,0,
-'npc_promocion',NULL);
+INSERT INTO `creature_template`(`entry`,`difficulty_entry_1`,`difficulty_entry_2`,`difficulty_entry_3`,`KillCredit1`,`KillCredit2`,`name`,`subname`,`IconName`,`gossip_menu_id`,`minlevel`,`maxlevel`,`exp`,`faction`,`npcflag`,`speed_walk`,`speed_run`,`speed_swim`,`speed_flight`,`detection_range`,`scale`,`rank`,`dmgschool`,`DamageModifier`,`BaseAttackTime`,`RangeAttackTime`,`BaseVariance`,`RangeVariance`,`unit_class`,`unit_flags`,`unit_flags2`,`dynamicflags`,`family`,`type`,`type_flags`,`lootid`,`pickpocketloot`,`skinloot`,`PetSpellDataId`,`VehicleId`,`mingold`,`maxgold`,`AIName`,`MovementType`,`HoverHeight`,`HealthModifier`,`ManaModifier`,`ArmorModifier`,`ExperienceModifier`,`RacialLeader`,`movementId`,`RegenHealth`,`mechanic_immune_mask`,`spell_school_immune_mask`,`flags_extra`,`ScriptName`,`VerifiedBuild`) VALUES (100002,0,0,0,0,0,'AzerothCore','Promotion',NULL,62000,80,80,0,35,1,1,1.14286,1,1,20,1.5,0,0,1,0,0,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,'',0,1,1,1,1,1,0,0,1,0,0,0,'npc_promocion',NULL);
 
 DELETE FROM `creature_template_model` WHERE `CreatureID`=100002;
 INSERT INTO `creature_template_model`(`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES

--- a/data/sql/db-world/base/npc_promotion_creature_template.sql
+++ b/data/sql/db-world/base/npc_promotion_creature_template.sql
@@ -1,6 +1,38 @@
 DELETE FROM `creature_template` WHERE `entry`=100002;
-INSERT INTO `creature_template`(`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`, `KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `speed_swim`, `speed_flight`, `detection_range`, `scale`, `rank`, `dmgschool`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, `BaseVariance`, `RangeVariance`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES
-(100002, 0, 0, 0, 0, 0, 'AzerothCore', 'Promotion', NULL, 62000, 80, 80, 0, 35, 1, 1, 1.14286, 1, 1, 20, 1.5, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 'npc_promocion', NULL);
+INSERT INTO `creature_template`(
+`entry`, `difficulty_entry_1`, `difficulty_entry_2`, `difficulty_entry_3`,
+`KillCredit1`, `KillCredit2`, `name`, `subname`, `IconName`,
+`gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`,
+`npcflag`, `speed_walk`, `speed_run`, `speed_swim`, `speed_flight`,
+`detection_range`, `scale`, `rank`, `dmgschool`, `DamageModifier`,
+`BaseAttackTime`, `RangeAttackTime`, `BaseVariance`, `RangeVariance`,
+`unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`,
+`family`, `type`, `type_flags`,
+`lootid`, `pickpocketloot`, `skinloot`,
+`PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`,
+`AIName`, `MovementType`, `HoverHeight`,
+`HealthModifier`, `ManaModifier`, `ArmorModifier`,
+`ExperienceModifier`, `RacialLeader`, `movementId`,
+`RegenHealth`, `mechanic_immune_mask`,
+`spell_school_immune_mask`, `flags_extra`,
+`ScriptName`, `VerifiedBuild`
+) VALUES
+(100002,0,0,0,
+0,0,'AzerothCore','Promotion',NULL,
+62000,80,80,0,35,
+1,1,1.14286,1,1,
+20,1.5,0,0,1,
+0,0,1,1,
+1,0,0,0,
+0,0,0,
+0,0,0,
+0,0,0,0,
+'',0,1,
+1,1,1,
+1,0,0,
+1,0,
+0,0,
+'npc_promocion',NULL);
 
 DELETE FROM `creature_template_model` WHERE `CreatureID`=100002;
 INSERT INTO `creature_template_model`(`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES


### PR DESCRIPTION
## Changes Proposed:
- Fixed INSERT statement for `creature_template` that was using non-existent columns (`trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`).
- Adapted SQL to match current AzerothCore database structure.
- Converted query to valid single-line format to avoid syntax issues when importing.

## Issues Addressed:
- Closes #

## SOURCE:
- Based on current `creature_template` schema from latest AzerothCore database.
- Verified using `DESCRIBE creature_template`.

## Tests Performed:
- SQL executed successfully on MySQL 8 without errors.
- No “Unknown column” errors after correction.
- NPC entry created correctly in database.
- Tested on Ubuntu + AzerothCore world DB.

## How to Test the Changes:
